### PR TITLE
Added functionality to parse a SCD model for future validation. 

### DIFF
--- a/server/src/model/index.ts
+++ b/server/src/model/index.ts
@@ -4,5 +4,5 @@
  * ------------------------------------------------------------------------------------------ */
 
 export * from './repository';
-export * from './schema';
+export * from './mim';
 export * from './validator';

--- a/server/src/model/mim.ts
+++ b/server/src/model/mim.ts
@@ -73,7 +73,8 @@ function componentToSchema(component: MimComponent): Schema {
   const desired = component.contents.filter((object) => object.desired);
   return {
     type: 'object',
-    fields: desired.map((object) => {
+    fields: desired.map((object) => 
+    {
       return {
         name: object.name,
         schema: object.schema,
@@ -85,7 +86,8 @@ function componentToSchema(component: MimComponent): Schema {
 function modelToSchema(model: Mim): Schema {
   return {
     type: 'object',
-    fields: model.contents.map((component) => {
+    fields: model.contents.map((component) => 
+    {
       return {
         name: component.name,
         schema: componentToSchema(component),

--- a/server/src/model/repository.ts
+++ b/server/src/model/repository.ts
@@ -15,7 +15,7 @@ import {
   Schema,
   isObject
 } from '../common';
-import { parseModel } from './schema';
+import { parseModel } from './mim';
 
 // GitHub repository content response schema
 // https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content

--- a/server/src/model/scd.ts
+++ b/server/src/model/scd.ts
@@ -1,0 +1,191 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+import * as D from 'io-ts/Decoder';
+import { fold } from 'fp-ts/lib/Either';
+import { pipe } from 'fp-ts/lib/function';
+
+import {
+  ArraySchema,
+  EnumSchema,
+  Schema
+} from '../common/schema';
+
+interface Scd {
+  scenarioConfigDefinition: ScdDefinition;
+}
+
+interface ScdDefinition {
+  name: string;
+  documents: Array<Document>;
+}
+
+interface Document {
+  configurations: Array<Configuration>;
+}
+
+interface Configuration {
+  name: string;
+  version: string;
+  schemaversion: string;
+  context: string;
+  settings: Array<Setting>;
+}
+
+interface Setting {
+  name: string;
+  defaultvalue: string,
+  datatype: string;
+}
+
+const Setting: D.Decoder<unknown, Setting> = D.struct({
+  name: D.string,
+  defaultvalue: D.string,
+  datatype: D.string,
+});
+
+const Configuration: D.Decoder<unknown, Configuration> = D.struct({
+  name: D.string,
+  version: D.string,
+  schemaversion: D.string,
+  context: D.string,
+  settings: D.array(Setting),
+});
+
+const Document: D.Decoder<unknown, Document> = D.struct({
+  configurations: D.array(Configuration),
+});
+
+const ScdDefinition: D.Decoder<unknown, ScdDefinition> = D.struct({
+  name: D.string,
+  documents: D.array(Document),
+});
+
+const Scd: D.Decoder<unknown, Scd> = D.struct({
+  scenarioConfigDefinition: ScdDefinition,
+});
+
+//This function allows the EnumSchema interface to be leveraged to store the default value of a key. In the future, it may be beneficial to create a string schema type that can store a value. 
+function stringLiteral(value: string): EnumSchema {
+  return {
+    type: 'enum',
+    valueSchema: 'string',
+    enumValues: [
+      {
+        name: '',
+        enumValue: value,
+      }
+    ]
+  };
+}
+
+function settingsToSchema(settings: Setting[]): Schema {
+  return {
+    type: 'object',
+    fields: settings.map((component) => 
+    {
+      return {
+        name: component.name,
+        schema: stringLiteral(component.defaultvalue),
+      };
+    })
+  };
+
+}
+
+function scenarioConfigurationToSchema(scenarioConfiguration: Configuration): ArraySchema {
+  return {
+    type: 'array',
+    elementSchema:
+    {
+      type: 'object',
+      fields: [
+        {
+          name: 'name',
+          schema: stringLiteral(scenarioConfiguration.name),
+        },
+        {
+          name: 'schemaversion',
+          schema: stringLiteral(scenarioConfiguration.schemaversion),
+        },
+        {
+          name: 'action',
+          schema: 'string',
+        },
+        {
+          name: scenarioConfiguration.name,
+          schema: settingsToSchema(scenarioConfiguration.settings),
+        }
+      ]
+    }
+  };
+}
+
+
+function docConfigurationToSchema(configuration: Configuration): Schema {
+  return {
+    type: 'object',
+    fields: [
+      {
+        name: 'schemaversion',
+        schema: stringLiteral(configuration.schemaversion),
+      },
+      {
+        name: 'id',
+        schema: 'string',
+      },
+      {
+        name: 'version',
+        schema: stringLiteral(configuration.version),
+      },
+      {
+        name: 'context',
+        schema: stringLiteral(configuration.context),
+      },
+      {
+        name: 'scenario',
+        schema: stringLiteral(configuration.name),
+      },
+    ]
+  };
+}
+
+function osConfigToSchema(osConfig: Configuration): Schema {
+  return {
+    type: 'object',
+    fields: [
+      {
+        name: 'Document',
+        schema: docConfigurationToSchema(osConfig),
+      },
+      {
+        name: 'Scenario',
+        schema: scenarioConfigurationToSchema(osConfig),
+      }
+    ]
+  };
+}
+
+
+function scdToSchema(scd: Scd): Schema {
+  return {
+    type: 'object',
+    fields: [{
+      name: 'OsConfiguration',
+      schema: osConfigToSchema(scd.scenarioConfigDefinition.documents[0].configurations[0]),
+    }
+    ]
+  };
+}
+
+export function parseModel(content: string): Schema | undefined {
+  return pipe(
+    Scd.decode(JSON.parse(content)),
+    fold(
+      (errors) => { throw new Error(D.draw(errors)); },
+      (model) => scdToSchema(model)
+    ),
+  );
+}
+


### PR DESCRIPTION
I added a scd.ts file in the server/src/model directory to represent a SCD object so that a SCD can be parsed, and a Schema object can be created using a SCD object for the purposes of validating a DC document. I also renamed the existing schema.ts file that was present in this directory to a mim.ts to more accurately represent the different model schemas. This pull request was created using a new fork to improve workflow and work off of the proper branch. These changes should be identical to an earlier pull request that was made. 