### PR TITLE
Integrated validation of generated DC document using SCD as a model schema. 

### DIFF
--- a/server/src/model/repository.ts
+++ b/server/src/model/repository.ts
@@ -15,7 +15,7 @@ import {
   Schema,
   isObject
 } from '../common';
-import { parseModel } from './mim';
+import { parseModel } from './scd';
 
 // GitHub repository content response schema
 // https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content


### PR DESCRIPTION
I altered the existing repository.ts file to use the SCD schema for validation. Please note that this removes the ability to validate documents using the mim model schema. In order to have the validation work, the vscode-osconfig extension settings must be configured to use models from a local path as a priority. This must be an absolute path. 